### PR TITLE
__unused modifier to avoid Xcode warnings

### DIFF
--- a/PXAPI/ABOAuthCore/OAuthCore.m
+++ b/PXAPI/ABOAuthCore/OAuthCore.m
@@ -10,7 +10,7 @@
 #import "NSData+Base64.h"
 #import <CommonCrypto/CommonHMAC.h>
 
-static NSInteger SortParameter(NSString *key1, NSString *key2, NSDictionary *context) {
+__unused static NSInteger SortParameter(NSString *key1, NSString *key2, NSDictionary *context) {
     NSComparisonResult r = [key1 compare:key2];
     if(r == NSOrderedSame) { // compare by value in this case
         NSString *value1 = [context objectForKey:key1];


### PR DESCRIPTION
Add __unused modifier on SortParameter function declaration
